### PR TITLE
Fix off-by-one error in MongoDB loader repeat loop

### DIFF
--- a/PlatformLoaders/MongoDbLoader.cs
+++ b/PlatformLoaders/MongoDbLoader.cs
@@ -24,7 +24,7 @@ namespace ChaosLoad.PlatformLoaders
             var mongoUrl = new MongoUrl(connection);
             var db = new MongoClient(mongoUrl).GetDatabase(mongoUrl.DatabaseName);
 
-            while (repeat == 0 || runCount <= repeat)
+            while (repeat == 0 || runCount < repeat)
             {
                 var paramCommand = paramReplacer.Replace(command);
                 db.RunCommand<dynamic>(paramCommand);


### PR DESCRIPTION
## Summary
Fixed an off-by-one error in the MongoDbLoader task execution loop that was causing one extra iteration to execute beyond the specified repeat count.

## Changes
- Changed loop condition from `runCount <= repeat` to `runCount < repeat` in the while loop
- This ensures the task executes exactly `repeat` times instead of `repeat + 1` times

## Details
The previous condition `runCount <= repeat` would allow the loop to continue when `runCount` equals `repeat`, resulting in one additional execution beyond the intended count. For example, with `repeat = 5`, the loop would execute 6 times (0, 1, 2, 3, 4, 5) instead of 5 times.

The corrected condition `runCount < repeat` ensures the loop terminates when `runCount` reaches the specified `repeat` value, executing exactly the requested number of times.

https://claude.ai/code/session_011rS7AjVaBGyUiTabjoeDxL